### PR TITLE
Column relationships, generic connection options, format markdown tables

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,15 +1,16 @@
 # List of contributors to this project
 
-| Name | Company | Role on this project |
-| --- | --- | --- |
-| [David Austin](https://www.linkedin.com/in/daustin5/) | Revance | Data architect |
-| [Laveena Kewlani](https://www.linkedin.com/in/laveena-kewlani-a831485a/) | PayPal | Solutions architect |
-| [Jean-Georges Perrin](https://www.linkedin.com/in/jgperrin/) | jgp.ai | Principal Technologist |
-| [Kruthika Potlapally](https://www.linkedin.com/in/kruthikap/) | Clairvoyant/EXL | Delivery |
-| [Amit Sutar](https://www.linkedin.com/in/amitbsutar/) | Clairvoyant/EXL | Delivery & architect |
-| Wenjie Guo | PayPal | Developer |
-| Shiqi Guo | PayPal | Developer |
-| Hongxin Jiang | PayPal | Developer |
-| [Kim Thies](https://www.linkedin.com/in/vtkthies/) | ProfitOptics | Advisor |
-| James Peterson |  | Contributor |
-| [Bart Vandekerckhove](https://www.linkedin.com/in/bartvandekerckhove/) | [Raito](https://www.raito.io/) | Contributor |
+| Name                                                                     | Company                                                      | Role on this project   |
+|--------------------------------------------------------------------------|--------------------------------------------------------------|------------------------|
+| [David Austin](https://www.linkedin.com/in/daustin5/)                    | Revance                                                      | Data architect         |
+| [Laveena Kewlani](https://www.linkedin.com/in/laveena-kewlani-a831485a/) | PayPal                                                       | Solutions architect    |
+| [Jean-Georges Perrin](https://www.linkedin.com/in/jgperrin/)             | jgp.ai                                                       | Principal Technologist |
+| [Kruthika Potlapally](https://www.linkedin.com/in/kruthikap/)            | Clairvoyant/EXL                                              | Delivery               |
+| [Amit Sutar](https://www.linkedin.com/in/amitbsutar/)                    | Clairvoyant/EXL                                              | Delivery & architect   |
+| Wenjie Guo                                                               | PayPal                                                       | Developer              |
+| Shiqi Guo                                                                | PayPal                                                       | Developer              |
+| Hongxin Jiang                                                            | PayPal                                                       | Developer              |
+| [Kim Thies](https://www.linkedin.com/in/vtkthies/)                       | ProfitOptics                                                 | Advisor                |
+| James Peterson                                                           |                                                              | Contributor            |
+| [Bart Vandekerckhove](https://www.linkedin.com/in/bartvandekerckhove/)   | [Raito](https://www.raito.io/)                               | Contributor            |
+| [Peter Flook](https://www.linkedin.com/in/peter-flook-bbb20ab2/)         | [Data Caterer](https://pflooky.github.io/data-caterer-docs/) | Contributor            |

--- a/docs/README.md
+++ b/docs/README.md
@@ -294,8 +294,9 @@ dataset:
 ```YAML
 dataset:
   - table: tab1
+    columns:
       - column: rcvr_id
-        isPrimary: true # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        isPrimaryKey: true # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
         businessName: receiver id
 # ...
         quality:

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,36 +70,36 @@ quality: null # See more information below
 tags: null
 ```
 
-|Key|UX label|Required|Description|
-| --- | --- | --- | --- | 
-|version         | Version          |Yes| Current version of the data contract.|
-|standardVersion | Standard version |No | Version of the standard used to build data contract. Default value is v2.2.0. |
-|uuid            | Identifier       |Yes| A unique identifier used to reduce the risk of dataset name collisions; initially the UUID will be created using a UUID generator tool ([example](https://www.uuidgenerator.net/)). However, we may want to develop a method that accepts a seed value using a combination of fields–such as name, kind and source–to create a repeatable value. |
-|username | Username | Yes | User credentials for connecting to the dataset; how the credentials will be stored/passed is outside of the scope of the contract. |
-|userConsumptionMode | Consumption mode | No | List of data modes for which the dataset may be used.  Expected sample values might be Analytical or Operational. <br/>Note: in the future, this will probably be replaced by ports. |
-|type | Type | Yes | Identifies the types of objects in the dataset.  For BigQuery the expected value would be tables. |
-|tenant | Tenant | No | Indicates the property the data is primarily associated with. Value is case insensitive. |
-|tags|Tags|No|a list of tags that may be assigned to the dataset, table or column; the `tags` keyword may appear at any level.
-|status|Status|Yes|Current status of the dataset.
-|sourceSystem|Source system|Yes|The system where the dataset resides.  Expected value is bigQuery
-|sourcePlatform|Source platform|Yes|The platform where the dataset resides. Expected value is googleCloudPlatform
-|server|Server|Yes|The server where the dataset resides.|
-|quantumName|Quantum name|Yes|The name of the data quantum or data product.
-productSlackChannel|Support Slack channel|No|Slack channel of the team responsible for maintaining the dataset.
-productFeedbackUrl|Feedback URL|No|The URL for submitting feedback to the team responsible for maintaining the dataset.|
-productDl|E-mail distribution list|No|The email distribution list (DL) of the persons or team responsible for maintaining the dataset.
-password|Password|Yes|User credentials for connecting to the dataset; how the credentials will be stored/passed is out of the scope of this contract.
-kind|Kind|Yes|The kind of Rosewall dataset being cataloged; Expected values are `virtualDataset` or `managedDataset`.
-driverVersion|Driver version|Yes|The version of the connection driver to be used to connect to the dataset.|
-driver|Driver|Yes|The connection driver required to connect to the dataset.|
-description.usage|Usage|No|intended usage of the dataset, table, or column (depending on the level); the key may appear at the dataset, table, or column level.|
-description.purpose|Purpose|No|Purpose of the dataset, table or column (depending on the level); the key may appear at the dataset, table, or column level.|
-description.limitations|Limitations|No|Limitations of the dataset, table or column (depending on the level); the key may appear at the dataset, table, or column level.|
-description|N/A|No|Object.|
-datasetProject|GCP project|Yes|GCP BigQuery dataset project name.|
-datasetName|BigQuery dataset name|Yes|GCP BigQuery dataset name.|
-|datasetDomain|Domain dataset|No|Name of the logical domain dataset the contract describes. This field is only required for output data contracts. Examples: `imdb_ds_aggregate`, `receiver_profile_out`,  `transaction_profile_out`.|
-database|Database|Yes|The database where the dataset resides.|
+| Key                     | UX label                 | Required | Description                                                                                                                                                                                                                                                                                                                                      |
+|-------------------------|--------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| version                 | Version                  | Yes      | Current version of the data contract.                                                                                                                                                                                                                                                                                                            |
+| standardVersion         | Standard version         | No       | Version of the standard used to build data contract. Default value is v2.2.0.                                                                                                                                                                                                                                                                    |
+| uuid                    | Identifier               | Yes      | A unique identifier used to reduce the risk of dataset name collisions; initially the UUID will be created using a UUID generator tool ([example](https://www.uuidgenerator.net/)). However, we may want to develop a method that accepts a seed value using a combination of fields–such as name, kind and source–to create a repeatable value. |
+| username                | Username                 | Yes      | User credentials for connecting to the dataset; how the credentials will be stored/passed is outside of the scope of the contract.                                                                                                                                                                                                               |
+| userConsumptionMode     | Consumption mode         | No       | List of data modes for which the dataset may be used.  Expected sample values might be Analytical or Operational. <br/>Note: in the future, this will probably be replaced by ports.                                                                                                                                                             |
+| type                    | Type                     | Yes      | Identifies the types of objects in the dataset.  For BigQuery the expected value would be tables.                                                                                                                                                                                                                                                |
+| tenant                  | Tenant                   | No       | Indicates the property the data is primarily associated with. Value is case insensitive.                                                                                                                                                                                                                                                         |
+| tags                    | Tags                     | No       | a list of tags that may be assigned to the dataset, table or column; the `tags` keyword may appear at any level.                                                                                                                                                                                                                                 |
+| status                  | Status                   | Yes      | Current status of the dataset.                                                                                                                                                                                                                                                                                                                   |
+| sourceSystem            | Source system            | Yes      | The system where the dataset resides.  Expected value is bigQuery                                                                                                                                                                                                                                                                                |
+| sourcePlatform          | Source platform          | Yes      | The platform where the dataset resides. Expected value is googleCloudPlatform                                                                                                                                                                                                                                                                    |
+| server                  | Server                   | Yes      | The server where the dataset resides.                                                                                                                                                                                                                                                                                                            |
+| quantumName             | Quantum name             | Yes      | The name of the data quantum or data product.                                                                                                                                                                                                                                                                                                    |
+| productSlackChannel     | Support Slack channel    | No       | Slack channel of the team responsible for maintaining the dataset.                                                                                                                                                                                                                                                                               |
+| productFeedbackUrl      | Feedback URL             | No       | The URL for submitting feedback to the team responsible for maintaining the dataset.                                                                                                                                                                                                                                                             |
+| productDl               | E-mail distribution list | No       | The email distribution list (DL) of the persons or team responsible for maintaining the dataset.                                                                                                                                                                                                                                                 |
+| password                | Password                 | Yes      | User credentials for connecting to the dataset; how the credentials will be stored/passed is out of the scope of this contract.                                                                                                                                                                                                                  |
+| kind                    | Kind                     | Yes      | The kind of Rosewall dataset being cataloged; Expected values are `virtualDataset` or `managedDataset`.                                                                                                                                                                                                                                          |
+| driverVersion           | Driver version           | Yes      | The version of the connection driver to be used to connect to the dataset.                                                                                                                                                                                                                                                                       |
+| driver                  | Driver                   | Yes      | The connection driver required to connect to the dataset.                                                                                                                                                                                                                                                                                        |
+| description.usage       | Usage                    | No       | intended usage of the dataset, table, or column (depending on the level); the key may appear at the dataset, table, or column level.                                                                                                                                                                                                             |
+| description.purpose     | Purpose                  | No       | Purpose of the dataset, table or column (depending on the level); the key may appear at the dataset, table, or column level.                                                                                                                                                                                                                     |
+| description.limitations | Limitations              | No       | Limitations of the dataset, table or column (depending on the level); the key may appear at the dataset, table, or column level.                                                                                                                                                                                                                 |
+| description             | N/A                      | No       | Object.                                                                                                                                                                                                                                                                                                                                          |
+| datasetProject          | GCP project              | Yes      | GCP BigQuery dataset project name.                                                                                                                                                                                                                                                                                                               |
+| datasetName             | BigQuery dataset name    | Yes      | GCP BigQuery dataset name.                                                                                                                                                                                                                                                                                                                       |
+| datasetDomain           | Domain dataset           | No       | Name of the logical domain dataset the contract describes. This field is only required for output data contracts. Examples: `imdb_ds_aggregate`, `receiver_profile_out`,  `transaction_profile_out`.                                                                                                                                             |
+| database                | Database                 | Yes      | The database where the dataset resides.                                                                                                                                                                                                                                                                                                          |
 
 ## Dataset & schema
 This section describes the dataset and the schema of the data contract. It is the support for data quality, which is detailed in the next section.
@@ -107,6 +107,11 @@ This section describes the dataset and the schema of the data contract. It is th
 ### Example
 
 ```YAML
+relationships:
+  tbl.txn_ref_dt:
+    - "tbl2.txn_value_dt" #can define relationship with a column in another table inside dataset, pattern -> ?(<dataset uuid>.)<table_name>.<column_name>?(.<nested_column_name>)
+    - "53581432-6c55-4ba2-a65f-72344a91553a.txn_file.transaction_date"  #or define relationship with column in another dataset by referring using the dataset uuid
+
 dataset:
   - table: tbl
     physicalName: tbl_1 # NEW in v2.1.0, Optional, default value is table name + version separated by underscores, as table_1_2_0
@@ -121,14 +126,17 @@ dataset:
     dataGranularity: Aggregation on columns txn_ref_dt, pmt_txn_id
     columns:
       - column: txn_ref_dt
-        isPrimary: false # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        isPrimaryKey: false # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        primaryKeyPosition: -1
         businessName: transaction reference date
         logicalType: date
         physicalType: date
         isNullable: false
         description: null
-        partitionStatus: true
-        clusterStatus: false
+        isPartitionKey: true
+        partitionKeyPosition: 1
+        isClusterKey: false
+        clusterKeyPosition: -1
         criticalDataElementStatus: false
         tags: null
         classification: null
@@ -143,27 +151,33 @@ dataset:
           - 2022-10-03
           - 2020-01-28
       - column: rcvr_id
-        isPrimary: true # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        isPrimaryKey: true # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        primaryKeyPosition: 1
         businessName: receiver id
         logicalType: string
         physicalType: varchar(18)
         isNullable: false
         description: A description for column rcvr_id.
-        partitionStatus: false
-        clusterStatus: true
+        isPartitionKey: false
+        partitionKeyPosition: -1
+        isClusterKey: true
+        clusterKeyPosition: 1
         criticalDataElementStatus: false
         tags: null
         classification: null
         encryptedColumnName: null
       - column: rcvr_cntry_code
-        isPrimary: false # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        isPrimaryKey: false # NEW in v2.1.0, Optional, default value is false, indicates whether the column is primary key in the table.
+        primaryKeyPosition: -1
         businessName: receiver country code
         logicalType: string
         physicalType: varchar(2)
         isNullable: false
         description: null
-        partitionStatus: false
-        clusterStatus: false
+        isPartitionKey: false
+        partitionKeyPosition: -1
+        isClusterKey: false
+        clusterKeyPosition: -1
         criticalDataElementStatus: false
         tags: null
         classification: null
@@ -173,37 +187,48 @@ dataset:
           - url: https://github.com/myorg/myrepo
             type: Reference implementation
         encryptedColumnName: rcvr_cntry_code_encrypted
+  - table: tbl2
+    columns:
+      - column: txn_value_dt
+        logicalType: date
+        physicalType: date
 ```
 
 ### Definitions
 
-|Key                                                |UX label|Required|Description|
-| ---  | --- | --- | --- | 
-|dataset                                                ||Yes|Array. A list of tables within the dataset to be cataloged.|
-|dataset.table                                          ||Yes|Name of the table being cataloged; the value should only contain the table name. Do not include the project or dataset name in the value.
-|dataset.table.physicalName                             ||No |Physical name of the table, default value is table name + version separated by underscores, as `table_1_2_0`.|
-|dataset.table.priorTableName                           ||No |Name of the previous version of the dataset, if applicable.|
-|dataset.table.description                              ||No |List of links to sources that provide more detail on column logic or values; examples would be URL to a GitHub repo, Collibra, on another tool.|
-|dataset.table.authoritativeDefinitions                 ||No |List of links to sources that provide more details on the table; examples would be a link to an external definition, a training video, a GitHub repo, Collibra, or another tool. Authoritative definitions follow the same structure in the standard.|
-|dataset.table.dataGranularity                          ||No |Granular level of the data in the table. Example would be `pmt_txn_id`.|
-|dataset.table.columns                                  ||Yes|Array. A list of columns in the table.|
-|dataset.table.columns.column                           ||Yes|The name of the column.|
-|dataset.table.columns.column.isPrimaryKey              ||No |Boolean value specifying whether the column is primary or not. Default is false.|
-|dataset.table.columns.column.businessName              ||No |the business name of the column.|
-|dataset.table.columns.column.logicalType               ||Yes|the logical column datatype.|
-|dataset.table.columns.column.physicalType              ||Yes|the physical column datatype.|
-|dataset.table.columns.column.isNullable                ||No |indicates if the column may contain Null values; possible values are true and false. Default is false.|
-|dataset.table.columns.column.partitionStatus           ||No |indicates if the column is partitioned; possible values are true and false.|
-|dataset.table.columns.column.clusterStatus             ||No |indicates of the column is clustered; possible values are true and false.|
-|dataset.table.columns.column.classification            ||No |Can be anything, like confidential, restricted, and public to more advanced categorization. Some companies like PayPal, use data classification indicating the class of data in the column; expected values are 1, 2, 3, 4, or 5.|
-|dataset.table.columns.column.authoritativeDefinitions  ||No |list of links to sources that provide more detail on column logic or values; examples would be URL to a GitHub repo, Collibra, on another tool.|
-|dataset.table.columns.column.encryptedColumnName       ||No |The column name within the table that contains the encrypted column value. For example, unencrypted column `email_address` might have an encryptedColumnName of `email_address_encrypt`.|
-|dataset.table.columns.column.transformSourceTables     ||No |List of sources used in column transformation.|
-|dataset.table.columns.column.transformLogic            ||No |Logic used in the column transformation.|
-|dataset.table.columns.column.transformDescription      ||No |Describes the transform logic in very simple terms.|
-|dataset.table.columns.column.sampleValues              ||No |List of sample column values.|
-|dataset.table.columns.column.criticalDataElementStatus ||No |True or false indicator; If element is considered a critical data element (CDE) then true else false.|
-|dataset.table.columns.column.tags                      ||No |A list of tags that may be assigned to the dataset, table or column; the tags keyword may appear at any level.|
+| Key                                                    | UX label | Required | Description                                                                                                                                                                                                                                           |
+|--------------------------------------------------------|----------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| relationships                                          |          | No       | Map of column name to list of other columns. Relationships between columns in this dataset to other columns, either in this dataset or outside.                                                                                                       |
+| dataset                                                |          | Yes      | Array. A list of tables within the dataset to be cataloged.                                                                                                                                                                                           |
+| dataset.table                                          |          | Yes      | Name of the table being cataloged; the value should only contain the table name. Do not include the project or dataset name in the value.                                                                                                             |
+| dataset.table.physicalName                             |          | No       | Physical name of the table, default value is table name + version separated by underscores, as `table_1_2_0`.                                                                                                                                         |
+| dataset.table.priorTableName                           |          | No       | Name of the previous version of the dataset, if applicable.                                                                                                                                                                                           |
+| dataset.table.description                              |          | No       | List of links to sources that provide more detail on column logic or values; examples would be URL to a GitHub repo, Collibra, on another tool.                                                                                                       |
+| dataset.table.authoritativeDefinitions                 |          | No       | List of links to sources that provide more details on the table; examples would be a link to an external definition, a training video, a GitHub repo, Collibra, or another tool. Authoritative definitions follow the same structure in the standard. |
+| dataset.table.dataGranularity                          |          | No       | Granular level of the data in the table. Example would be `pmt_txn_id`.                                                                                                                                                                               |
+| dataset.table.columns                                  |          | Yes      | Array. A list of columns in the table.                                                                                                                                                                                                                |
+| dataset.table.columns.column                           |          | Yes      | The name of the column.                                                                                                                                                                                                                               |
+| dataset.table.columns.column.isPrimaryKey              |          | No       | Boolean value specifying whether the column is primary or not. Default is false.                                                                                                                                                                      |
+| dataset.table.columns.column.primaryKeyPosition        |          | No       | If column is a primary key, the position of the primary key column. Starts from 1. Example of `account_id, name` being primary key columns, `account_id` has primaryKeyPosition 1 and `name` primaryKeyPosition 2. Default to -1.                     |
+| dataset.table.columns.column.businessName              |          | No       | The business name of the column.                                                                                                                                                                                                                      |
+| dataset.table.columns.column.logicalType               |          | Yes      | The logical column datatype.                                                                                                                                                                                                                          |
+| dataset.table.columns.column.physicalType              |          | Yes      | The physical column datatype.                                                                                                                                                                                                                         |
+| dataset.table.columns.column.isNullable                |          | No       | Indicates if the column may contain Null values; possible values are true and false. Default is false.                                                                                                                                                |
+| dataset.table.columns.column.isUnique                  |          | No       | Indicates if the column contains unique values; possible values are true and false. Default is false.                                                                                                                                                 |
+| dataset.table.columns.column.isPartitionKey            |          | No       | Indicates if the column is partitioned; possible values are true and false.                                                                                                                                                                           |
+| dataset.table.columns.column.partitionKeyPosition      |          | No       | If column is used for partitioning, the position of the partition column. Starts from 1. Example of `country, year` being partition columns, `country` has partitionKeyPosition 1 and `year` partitionKeyPosition 2. Default to -1.                   |
+| dataset.table.columns.column.isClusterKey              |          | No       | Indicates of the column is clustered; possible values are true and false.                                                                                                                                                                             |
+| dataset.table.columns.column.clusterKeyPosition        |          | No       | If column is used for clustering, the position of the cluster column. Starts from 1. Example of `year, date` being cluster columns, `year` has clusterKeyPosition 1 and `date` clusterKeyPosition 2. Default to -1.                                   |
+| dataset.table.columns.column.classification            |          | No       | Can be anything, like confidential, restricted, and public to more advanced categorization. Some companies like PayPal, use data classification indicating the class of data in the column; expected values are 1, 2, 3, 4, or 5.                     |
+| dataset.table.columns.column.authoritativeDefinitions  |          | No       | List of links to sources that provide more detail on column logic or values; examples would be URL to a GitHub repo, Collibra, on another tool.                                                                                                       |
+| dataset.table.columns.column.encryptedColumnName       |          | No       | The column name within the table that contains the encrypted column value. For example, unencrypted column `email_address` might have an encryptedColumnName of `email_address_encrypt`.                                                              |
+| dataset.table.columns.column.transformSourceTables     |          | No       | List of sources used in column transformation.                                                                                                                                                                                                        |
+| dataset.table.columns.column.transformLogic            |          | No       | Logic used in the column transformation.                                                                                                                                                                                                              |
+| dataset.table.columns.column.transformDescription      |          | No       | Describes the transform logic in very simple terms.                                                                                                                                                                                                   |
+| dataset.table.columns.column.sampleValues              |          | No       | List of sample column values.                                                                                                                                                                                                                         |
+| dataset.table.columns.column.criticalDataElementStatus |          | No       | True or false indicator; If element is considered a critical data element (CDE) then true else false.                                                                                                                                                 |
+| dataset.table.columns.column.tags                      |          | No       | A list of tags that may be assigned to the dataset, table or column; the tags keyword may appear at any level.                                                                                                                                        |
+| dataset.table.columns.column.columns                   |          | No       | Nested column definitions following `dataset.table.columns.column` definition.                                                                                                                                                                        |
 
 ## Data quality 
 This section describes data quality rules & parameters. They are tightly linked to the schema described in the previous section.
@@ -295,22 +320,22 @@ dataset:
 
 ### Definitions
 
-|Key|UX label|Required|Description|
-| --- | --- | --- | --- | 
-|quality||No|Quality tag with all the relevant information for rule setup and execution.|
-|quality.code||No|The Rosewall data quality code(s) indicating which quality checks need to be performed at the dataset, table or column level; The quality keyword may appear at any level; Some quality checks require parameters such so the check can be completed (eg, list of fields used to identify a distinct row) therefore some quality checks may be followed by a single value or an array; See appendix for link to quality checks.
-|quality.templateName||Yes|The template name which indicates what is the equivalent template from the tool. 
-|quality.description||No|Describe the quality check to be completed.
-|quality.toolName||Yes|Name of the tool used to complete the quality check; Most will be Elevate initially.|
-|quality.toolRuleName||No|Name of the quality tool's rule created to complete the |quality check.|
-|quality.dimension||No|The key performance indicator (KPI) or dimension for data quality.|
-|quality.columns||No|List of columns to be used in the quality check
-|quality.column||No|To be used in lieu of quality.columns when only a single column is required for the quality check.|
-|quality.type||No|The type of quality check.|
-|quality.severity||No|The severance of the quality rule.|
-|quality.businessImpact||No|Consequences of the rule failure.|
-|quality.scheduleCronExpression||No|Rule execution schedule details.|
-|quality.customProperties||No|Additional properties required for rule execution. |
+| Key                            | UX label | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|--------------------------------|----------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| quality                        |          | No       | Quality tag with all the relevant information for rule setup and execution.                                                                                                                                                                                                                                                                                                                                                     |
+| quality.code                   |          | No       | The Rosewall data quality code(s) indicating which quality checks need to be performed at the dataset, table or column level; The quality keyword may appear at any level; Some quality checks require parameters such so the check can be completed (eg, list of fields used to identify a distinct row) therefore some quality checks may be followed by a single value or an array; See appendix for link to quality checks. |
+| quality.templateName           |          | Yes      | The template name which indicates what is the equivalent template from the tool.                                                                                                                                                                                                                                                                                                                                                |
+| quality.description            |          | No       | Describe the quality check to be completed.                                                                                                                                                                                                                                                                                                                                                                                     |
+| quality.toolName               |          | Yes      | Name of the tool used to complete the quality check; Most will be Elevate initially.                                                                                                                                                                                                                                                                                                                                            |
+| quality.toolRuleName           |          | No       | Name of the quality tool's rule created to complete the quality check.                                                                                                                                                                                                                                                                                                                                                          |
+| quality.dimension              |          | No       | The key performance indicator (KPI) or dimension for data quality.                                                                                                                                                                                                                                                                                                                                                              |
+| quality.columns                |          | No       | List of columns to be used in the quality check                                                                                                                                                                                                                                                                                                                                                                                 |
+| quality.column                 |          | No       | To be used in lieu of quality.columns when only a single column is required for the quality check.                                                                                                                                                                                                                                                                                                                              |
+| quality.type                   |          | No       | The type of quality check.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| quality.severity               |          | No       | The severance of the quality rule.                                                                                                                                                                                                                                                                                                                                                                                              |
+| quality.businessImpact         |          | No       | Consequences of the rule failure.                                                                                                                                                                                                                                                                                                                                                                                               |
+| quality.scheduleCronExpression |          | No       | Rule execution schedule details.                                                                                                                                                                                                                                                                                                                                                                                                |
+| quality.customProperties       |          | No       | Additional properties required for rule execution.                                                                                                                                                                                                                                                                                                                                                                              |
 
 ## Pricing
 This section covers pricing when you bill your customer for using this data product. Pricing is experimental in v2.1.1 of the data contract.
@@ -326,12 +351,12 @@ price:
 
 ### Definitions
 
-|Key|UX label|Required|Description|
-| --- | --- | --- | --- | 
-price||No|Object
-price.priceAmount||No|Subscription price per unit of measure in `priceUnit`.|
-price.priceCurrency||No|Currency of the subscription price in `price.priceAmount`.|
-price.priceUnit||No|The unit of measure for calculating cost. Examples megabyte, gigabyte.|
+| Key                 | UX label | Required | Description                                                            |
+|---------------------|----------|----------|------------------------------------------------------------------------|
+| price               |          | No       | Object                                                                 |
+| price.priceAmount   |          | No       | Subscription price per unit of measure in `priceUnit`.                 |
+| price.priceCurrency |          | No       | Currency of the subscription price in `price.priceAmount`.             |
+| price.priceUnit     |          | No       | The unit of measure for calculating cost. Examples megabyte, gigabyte. |
 
 ## Stakeholders
 This section lists stakeholders and the history of their relation with this data contract.
@@ -360,14 +385,14 @@ stakeholders:
 ### Definitions
 The UX label is the label used in the UI and other user experiences. It is not limited to BlueRacket.
 
-|Key|UX label|Required|Description|
-| --- | --- | --- | --- |
-stakeholders||No|Array
-stakeholders.username||No|The stakeholder's username or email.|
-stakeholders.role||No|The stakeholder's job role; Examples might be owner, data steward. There is no limit on the role.|
-stakeholders.dateIn||No|The date when the user became a stakeholder.|
-stakeholders.dateOut||No|The date when the user ceased to be a stakeholder|
-stakeholders.replacedByUsername||No|The username of the user who replaced the stakeholder|
+| Key                             | UX label | Required | Description                                                                                       |
+|---------------------------------|----------|----------|---------------------------------------------------------------------------------------------------|
+| stakeholders                    |          | No       | Array                                                                                             |
+| stakeholders.username           |          | No       | The stakeholder's username or email.                                                              |
+| stakeholders.role               |          | No       | The stakeholder's job role; Examples might be owner, data steward. There is no limit on the role. |
+| stakeholders.dateIn             |          | No       | The date when the user became a stakeholder.                                                      |
+| stakeholders.dateOut            |          | No       | The date when the user ceased to be a stakeholder                                                 |
+| stakeholders.replacedByUsername |          | No       | The username of the user who replaced the stakeholder                                             |
 
 ## Roles
 This section lists the roles that a consumer may need to access the dataset depending on the type of access they require.
@@ -396,13 +421,13 @@ roles:
 
 ### Definitions
 
-|Key|UX label|Required|Description|
-| --- | --- | --- | --- |
-roles||Yes|Array. A list of roles that will provide user access to the dataset.|
-roles.role||Yes|name of the IAM role that provides access to the dataset; the value will generally come directly from the "BQ dataset to IAM roles mapping" document.|
-roles.access||Yes|the type of access provided by the IAM role; the value will generally come directly from the "BQ dataset to IAM roles mapping" document.|
-roles.firstLevelApprovers||No|the name(s) of the first level approver(s) of the role; the value will generally come directly from the "BQ dataset to IAM roles mapping" document.|
-roles.secondLevelApprovers||No|the name(s) of the second level approver(s) of the role; the value will generally come directly from the "BQ dataset to IAM roles mapping" document.|
+| Key                        | UX label | Required | Description                                                                                                                                           |
+|----------------------------|----------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| roles                      |          | Yes      | Array. A list of roles that will provide user access to the dataset.                                                                                  |
+| roles.role                 |          | Yes      | name of the IAM role that provides access to the dataset; the value will generally come directly from the "BQ dataset to IAM roles mapping" document. |
+| roles.access               |          | Yes      | the type of access provided by the IAM role; the value will generally come directly from the "BQ dataset to IAM roles mapping" document.              |
+| roles.firstLevelApprovers  |          | No       | the name(s) of the first level approver(s) of the role; the value will generally come directly from the "BQ dataset to IAM roles mapping" document.   |
+| roles.secondLevelApprovers |          | No       | the name(s) of the second level approver(s) of the role; the value will generally come directly from the "BQ dataset to IAM roles mapping" document.  |
 
 
 ## Service-level agreement
@@ -448,16 +473,16 @@ slaProperties:
 
 ### Definitions
 
-|Key|UX label|Required|Description|
-| --- | --- | --- | --- |
-|slaDefaultColumn|Default SLA column(s)|No|Columns (using the Table.Column notation) to do the checks on. By default, it is the partition column.|
-|slaProperties|SLA|No|A list of key/value pairs for SLA specific properties. There is no limit on the type of properties (more details to come).|
-|slaProperties.property|Property|Yes|Specific property in SLA, check the periodic table. May requires units (more details to come).|
-|slaProperties.value|Value|Yes|Agreement value. The label will change based on the property itself.|
-|slaProperties.valueExt|Extended value|No - unless needed by property|Extended agreement value. The label will change based on the property itself.|
-|slaProperties.unit|Unit|No - unless needed by property|**d**, day, days for days; **y**, yr, years for years, etc. Units use the ISO standard.|
-|slaProperties.column|Column(s)|No|Column(s) to check on. Multiple columns should be extremely rare and, if so, separated by commas.|
-|slaProperties.driver|Driver|No|Describes the importance of the SLA from the list of: regulatory, analytics, operational.|
+| Key                    | UX label              | Required                       | Description                                                                                                                |
+|------------------------|-----------------------|--------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| slaDefaultColumn       | Default SLA column(s) | No                             | Columns (using the Table.Column notation) to do the checks on. By default, it is the partition column.                     |
+| slaProperties          | SLA                   | No                             | A list of key/value pairs for SLA specific properties. There is no limit on the type of properties (more details to come). |
+| slaProperties.property | Property              | Yes                            | Specific property in SLA, check the periodic table. May requires units (more details to come).                             |
+| slaProperties.value    | Value                 | Yes                            | Agreement value. The label will change based on the property itself.                                                       |
+| slaProperties.valueExt | Extended value        | No - unless needed by property | Extended agreement value. The label will change based on the property itself.                                              |
+| slaProperties.unit     | Unit                  | No - unless needed by property | **d**, day, days for days; **y**, yr, years for years, etc. Units use the ISO standard.                                    |
+| slaProperties.column   | Column(s)             | No                             | Column(s) to check on. Multiple columns should be extremely rare and, if so, separated by commas.                          |
+| slaProperties.driver   | Driver                | No                             | Describes the importance of the SLA from the list of: regulatory, analytics, operational.                                  |
 
 ## Other properties
 This section covers other properties you may find in a data contract.
@@ -480,10 +505,10 @@ contractCreatedTs: 2022-11-15 02:59:43
 
 ### Definitions
 
-|Key|UX label|Required|Description|
-| --- | --- | --- | --- |
-customProperties||No|A list of key/value pairs for custom properties. Initially created to support the REF ruleset property.
-customProperties.property||No|The name of the key. Names should be in camel case–the same as if they were permanent properties in the contract.
-customProperties.value||No|The value of the key.
-systemInstance||No|System Instance name where the dataset resides.
-contractCreatedTs||No|Timestamp in UTC of when the data contract was created.
+| Key                       | UX label | Required | Description                                                                                                       |
+|---------------------------|----------|----------|-------------------------------------------------------------------------------------------------------------------|
+| customProperties          |          | No       | A list of key/value pairs for custom properties. Initially created to support the REF ruleset property.           |
+| customProperties.property |          | No       | The name of the key. Names should be in camel case–the same as if they were permanent properties in the contract. |
+| customProperties.value    |          | No       | The value of the key.                                                                                             |
+| systemInstance            |          | No       | System Instance name where the dataset resides.                                                                   |
+| contractCreatedTs         |          | No       | Timestamp in UTC of when the data contract was created.                                                           |

--- a/examples/fundamentals/connection-options.yaml
+++ b/examples/fundamentals/connection-options.yaml
@@ -1,0 +1,11 @@
+# Physical access
+connectionType: "jdbc"  #type of connection could be jms, database, http, etc.
+connectionOptions:  #map of connection options that can be used based on connectionType
+  driver: null
+  driverVersion: null
+  server: null
+  database: pypl-edw.pp_access_views
+  url: "jdbc:postgresql://${env.host}:${env.port}"
+  username: "${env.username}"
+  password: "${env.password}"
+schedulerAppName: name_coming_from_scheduler # NEW 2.1.0 Required if you want to schedule stuff, comes from DataALM.

--- a/examples/quality/column-accuracy.yaml
+++ b/examples/quality/column-accuracy.yaml
@@ -1,15 +1,15 @@
 - table: Air_Quality
   description: Air quality of the city of New York
-  authoritativeDefinitions: 
-    - url: https://catalog.data.gov/dataset/air-quality 
+  authoritativeDefinitions:
+    - url: https://catalog.data.gov/dataset/air-quality
       type: Reference definition on Data.gov
   dataGranularity: Raw records
   columns:
-  - column: DataValue
-    businessName: Measured value
-    logicalType: number
-    physicalType: float(3,2)
-        quality:
+    - column: DataValue
+      businessName: Measured value
+      logicalType: number
+      physicalType: float(3,2)
+      quality:
         - templateName: RangeCheck
           toolName: ClimateQuantumDataQualityPackage
           description: 'This column should contain positive values under 500'

--- a/examples/quality/column-completeness.yaml
+++ b/examples/quality/column-completeness.yaml
@@ -6,7 +6,7 @@
   dataGranularity: Raw records
   columns:
     - column: UniqueID
-      isPrimary: true
+      isPrimaryKey: true
       businessName: Unique identifier
       logicalType: number
       physicalType: int

--- a/examples/quality/column-completeness.yaml
+++ b/examples/quality/column-completeness.yaml
@@ -1,16 +1,16 @@
 - table: Air_Quality
-  description: Air quality of the city of New York 
-  authoritativeDefinitions: 
-    - url: https://catalog.data.gov/dataset/air-quality 
+  description: Air quality of the city of New York
+  authoritativeDefinitions:
+    - url: https://catalog.data.gov/dataset/air-quality
       type: Reference definition on Data.gov
   dataGranularity: Raw records
   columns:
-  - column: UniqueID
-    isPrimary: true
-    businessName: Unique identifier
-    logicalType: number
-    physicalType: int
-        quality:
+    - column: UniqueID
+      isPrimary: true
+      businessName: Unique identifier
+      logicalType: number
+      physicalType: int
+      quality:
         - templateName: NullCheck
           toolName: ClimateQuantumDataQualityPackage
           description: This column should not contain null values

--- a/examples/quality/column-validity.yaml
+++ b/examples/quality/column-validity.yaml
@@ -10,13 +10,13 @@
     businessName: Unique identifier
     logicalType: number
     physicalType: int
-        quality:
-        - templateName: RangeCheck
-          toolName: ClimateQuantumDataQualityPackage
-          description: This column should not contain values under 100000
-          dimension: validity
-          severity: error
-          businessImpact: operational
-          customProperties:
-            - property: min
-              value: 100000
+    quality:
+      - templateName: RangeCheck
+        toolName: ClimateQuantumDataQualityPackage
+        description: This column should not contain values under 100000
+        dimension: validity
+        severity: error
+        businessImpact: operational
+        customProperties:
+          - property: min
+            value: 100000

--- a/examples/quality/column-validity.yaml
+++ b/examples/quality/column-validity.yaml
@@ -6,7 +6,7 @@
   dataGranularity: Raw records
   columns:
   - column: UniqueID
-    isPrimary: true
+    isPrimaryKey: true
     businessName: Unique identifier
     logicalType: number
     physicalType: int

--- a/examples/schema/dataset-with-tables-and-relationships.yaml
+++ b/examples/schema/dataset-with-tables-and-relationships.yaml
@@ -1,0 +1,43 @@
+relationships:
+  accounts.account_id:
+    - "transactions.account_id"
+    - "balances.account_number"
+    - "53581432-6c55-4ba2-a65f-72344a91553a.file_accounts.account_id" #can refer to columns in other datasets
+
+dataset:
+  - table: accounts
+    columns:
+    - column: account_id
+      businessName: Customer account ID
+      logicalType: string
+      physicalType: text
+      samples:
+        - "ACC12345678"
+    - column: name
+      businessName: Customer name
+      logicalType: string
+      physicalType: text
+  - table: transactions
+    columns:
+    - column: account_id
+      businessName: Customer account ID
+      logicalType: string
+      physicalType: text
+    - column: amount
+      businessName: Transaction amount
+      logicalType: double
+      physicalType: double
+  - table: balances
+    columns:
+    - column: account_number
+      businessName: Customer account number
+      logicalType: string
+      physicalType: text
+      transformSourceTables:
+        - accounts
+      transformLogic: "REPLACE(accounts.account_id, 'ACC', '')"
+      transformDescription: Remove the ACC prefix from the accounts account_id
+    - column: balance
+      businessName: Customer balance
+      logicalType: double
+      physicalType: double

--- a/examples/schema/nested-columns.yaml
+++ b/examples/schema/nested-columns.yaml
@@ -1,0 +1,13 @@
+- table: tbl
+  columns:
+    - column: transaction_summary
+      businessName: Summary details of customer transactions
+      logicalType: string
+      physicalType: text
+      columns:
+        - column: last_txn_date
+          businessName: Date of the last transaction
+          logicalType: date
+        - column: last_3_months_spend
+          businessName: Aggregation of debit transaction amounts in the previous 3 months
+          logicalType: double


### PR DESCRIPTION
Following suggestions:

- Column relationships defined at dataset level
  - Use pattern `?(<dataset_uuid>.)<table_name>.<column_name>?(.<nested_column_name>+)` to allow for cross dataset relationships
- Generic connection options
  - Similar to Spark style connections where a map of string -> string is defined
  - Valid connection options defined by connection type
  - Allows for other data source definitions to be defined such as JMS, non-JDBC databases, HTTP
- Standardise primaryKey, partitionKey and clusterKey
- Add in primaryKeyPosition, partitionKeyPosition, clusterKeyPosition and isUnique for column definition